### PR TITLE
Retry Throttling errors in CloudFormation waiters.

### DIFF
--- a/aws-sdk-core/apis/cloudformation/2010-05-15/waiters-2.json
+++ b/aws-sdk-core/apis/cloudformation/2010-05-15/waiters-2.json
@@ -15,6 +15,11 @@
           "matcher": "error",
           "expected": "ValidationError",
           "state": "retry"
+        },
+        {
+          "matcher": "error",
+          "expected": "Throttling",
+          "state": "retry"
         }
       ]
     },
@@ -64,6 +69,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -113,6 +123,11 @@
           "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
           "matcher": "pathAny",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -175,6 +190,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     }


### PR DESCRIPTION
This is a cherry-pick commit from https://github.com/acquia/aws-sdk-ruby/tree/v2.9.5-acquia1 branch which is currently used in worker.

**Current worker version:** v2.9.5-acquia1
**Current API version:** v2.11.3-acquia

Once this PR is merged, would like to update both repos to use v2.11.3-acquia