### PR TITLE
Retry Throttling errors in CloudFormation waiters.

### DIFF
--- a/aws-sdk-core/apis/cloudformation/2010-05-15/waiters-2.json
+++ b/aws-sdk-core/apis/cloudformation/2010-05-15/waiters-2.json
@@ -15,6 +15,11 @@
           "matcher": "error",
           "expected": "ValidationError",
           "state": "retry"
+        },
+        {
+          "matcher": "error",
+          "expected": "Throttling",
+          "state": "retry"
         }
       ]
     },
@@ -64,6 +69,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -113,6 +123,11 @@
           "expected": "UPDATE_ROLLBACK_IN_PROGRESS",
           "matcher": "pathAny",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     },
@@ -175,6 +190,11 @@
           "expected": "ValidationError",
           "matcher": "error",
           "state": "failure"
+        },
+        {
+          "expected": "Throttling",
+          "matcher": "error",
+          "state": "retry"
         }
       ]
     }


### PR DESCRIPTION
Updating aws-sdk-ruby to the latest v2 version by integrating our cloudformation polling change.
